### PR TITLE
Name SetFit and Jobs in data curation post title

### DIFF
--- a/posts/2026/agents-data-curation/index.qmd
+++ b/posts/2026/agents-data-curation/index.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Using agents to build efficient classifiers for data curation"
+title: "Building data curation classifiers with agents, SetFit and Jobs"
 description: "Building a small document classifier with an agent, then using Hugging Face Jobs to label 1% of the English FinePDFs-Edu dataset."
 author: "Daniel van Strien"
 date: "2026-09-10"


### PR DESCRIPTION
Name SetFit and Jobs in the post title while keeping agents and data curation as the framing.

Changes the title to “Building data curation classifiers with agents, SetFit and Jobs”. The post URL remains the same.

Validation: Quarto render passed; checked the rendered heading, page title, Open Graph title and Twitter title. Preview image metadata is unchanged.
