### PR TITLE
Simplify post categories to a controlled 16-tag vocabulary

### DIFF
--- a/posts/2024/11/local-vision-language-model-lm-studio.ipynb
+++ b/posts/2024/11/local-vision-language-model-lm-studio.ipynb
@@ -15,6 +15,7 @@
     "toc: true\n",
     "toc-depth: 3\n",
     "\n",
+    "categories: [computer-vision, huggingface]\n",
     "---\n"
    ]
   },

--- a/posts/2024/11/local-vision-language-model-lm-studio.ipynb
+++ b/posts/2024/11/local-vision-language-model-lm-studio.ipynb
@@ -15,7 +15,7 @@
     "toc: true\n",
     "toc-depth: 3\n",
     "\n",
-    "categories: [computer-vision, huggingface]\n",
+    "categories: [computer-vision, huggingface, local-ai]\n",
     "---\n"
    ]
   },

--- a/posts/2025/deepseek/distil-deepseek-modernbert.ipynb
+++ b/posts/2025/deepseek/distil-deepseek-modernbert.ipynb
@@ -9,7 +9,7 @@
     "description: \"How can we use the reasoning ability of DeepSeek to generate synthetic labels for fine tuning a ModernBERT model?\"\n",
     "author: \"Daniel van Strien\"\n",
     "date: \"2025-01-29\"\n",
-    "categories: [\"huggingface\", \"datasets\", \"arxiv\", \"synthetic-data\", \"deepseek\"]\n",
+    "categories: [huggingface, datasets, synthetic-data, fine-tuning]\n",
     "image: https://github.com/davanstrien/blog/raw/refs/heads/main/posts/2025/modern-bert-sythetic-labels/bert-illustration.webp\n",
     "twitter-card:\n",
     "  title: \"Distiling DeepSeek reasoning to ModernBERT classifiers\"\n",

--- a/posts/2025/grpo/trl_log_completions_to_hf_datasets.ipynb
+++ b/posts/2025/grpo/trl_log_completions_to_hf_datasets.ipynb
@@ -9,7 +9,7 @@
         "description: \"Log GRPO training completions from trl to a 🤗 Dataset repo for easy analysis\"\n",
         "author: \"Daniel van Strien\"\n",
         "date: \"2025-02-20\"\n",
-        "categories: [\"huggingface\", \"trl\", \"datasets\"]\n",
+        "categories: [huggingface, datasets, fine-tuning]\n",
         "image: https://raw.githubusercontent.com/davanstrien/blog/refs/heads/main/posts/2025/grpo/assets/whale.png\n",
         "twitter-card:\n",
         "  title: \"GRPO Log Completions to 🤗 Datasets\"\n",

--- a/posts/2025/hf-jobs/vllm-batch-inference.ipynb
+++ b/posts/2025/hf-jobs/vllm-batch-inference.ipynb
@@ -9,7 +9,7 @@
     "title: \"Efficient batch inference for LLMs with vLLM + UV Scripts on HF Jobs\"\n",
     "description: \"Generate responses for thousands of dataset prompts using Qwen/Qwen3-30B-A3B-Instruct-2507 across 4 GPUs with automatic prompt filtering and tensor parallelism\"\n",
     "author: \"Daniel van Strien\"\n",
-    "categories: [\"huggingface\", \"uv-scripts\", \"vllm\", \"hf Jobs\"]\n",
+    "categories: [huggingface, vllm, hf-jobs]\n",
     "image: https://github.com/davanstrien/blog/blob/a2ff89fbd48d22e0f4a984b03a81a92c07080eea/posts/2025/hf-jobs/assets/is-this-uv-script.jpg?raw=true\n",
     "date: 2025-07-30\n",
     "---"

--- a/posts/2025/iconclass-vlm-sft/trl-vlm-fine-tuning-iconclass.ipynb
+++ b/posts/2025/iconclass-vlm-sft/trl-vlm-fine-tuning-iconclass.ipynb
@@ -10,7 +10,7 @@
     "description: \"Learn how to fine-tune open-source VLMs like Qwen2.5-VL for specialized art history tasks using Iconclass metadata. This tutorial shows how to use TRL's new VLM support with Hugging Face Jobs for cloud-based training - no local GPU required!\"\n",
     "author: \"Daniel van Strien\"\n",
     "date: \"2025-09-04\"\n",
-    "categories: [\"huggingface\", \"uv-scripts\", \"vlm\", \"hf Jobs\", \"art-history\", \"iconclass\"]\n",
+    "categories: [huggingface, hf-jobs, computer-vision, art-history, fine-tuning]\n",
     "image: https://github.com/davanstrien/blog/blob/main/posts/2025/iconclass-vlm-sft/assets/iconclass-post-visual.png?raw=true\n",
     "twitter-card:\n",
     "  title: \"Fine-tuning VLMs for Art History with TRL and HF Jobs\"\n",

--- a/posts/2025/reasoning-models/generating-structured-data-extraction-dataset-with-qwq-and-curator.md
+++ b/posts/2025/reasoning-models/generating-structured-data-extraction-dataset-with-qwq-and-curator.md
@@ -3,7 +3,7 @@ title: "Using QwQ to generate a reasoning dataset for structured data extraction
 description: "Learn how to use QwQ-32B to generate synthetic reasoning datasets for training smaller models on structured data extraction tasks"
 author: "Daniel van Strien"
 date: "2025-03-11"
-categories: ["huggingface", "datasets", "synthetic-data", "qwq", "reasoning"]
+categories: [huggingface, datasets, synthetic-data, structured-extraction]
 image: "https://github.com/davanstrien/blog/raw/refs/heads/main/posts/2025/reasoning-models/curator.webp"
 twitter-card:
   title: "Using QwQ to generate a reasoning dataset for structured data extraction"

--- a/posts/2025/vllm/modern_inference_modernbert.ipynb
+++ b/posts/2025/vllm/modern_inference_modernbert.ipynb
@@ -11,7 +11,7 @@
         "description: \"Modern Inference for modern models. Using vLLM to scale ModernBERT based classifier models to clean and curate datasets\"\n",
         "author: \"Daniel van Strien\"\n",
         "date: \"2025-04-24\"\n",
-        "categories: [\"huggingface\", \"datasets\", \"arxiv\", \"vllm\", \"modernbert\"]\n",
+        "categories: [huggingface, datasets, vllm]\n",
         "image: https://github.com/davanstrien/blog/raw/refs/heads/main/posts/2025/vllm/vllm-modernbert.png\n",
         "twitter-card:\n",
         "  title: \"Efficient Inference for ModernBERT Classifiers Using vLLM \"\n",

--- a/posts/2025/who-benefits-rethinking-library-data-ai/libraries-as-training-data.qmd
+++ b/posts/2025/who-benefits-rethinking-library-data-ai/libraries-as-training-data.qmd
@@ -2,7 +2,7 @@
 title: "Who Benefits? Rethinking Library Data in the Age of AI"
 author: "Daniel van Strien"
 date: "2025-06-09"
-categories: [AI, libraries, datasets, GLAM, community]
+categories: [libraries, datasets, glam]
 description: "From data providers to AI partners: How libraries can collaborate with developers to build tools that improve collections, enhance discovery, and serve communities while contributing to responsible AI development."
 image: "https://github.com/davanstrien/blog/blob/7f7b15b8a85a9967f18b994b7c80f1cbbcfedbb0/posts/2025/who-benefits-rethinking-library-data-ai/assets/finebooks-illusration.png?raw=true"
 draft: false

--- a/posts/2026/agent-race-traces/index.qmd
+++ b/posts/2026/agent-race-traces/index.qmd
@@ -3,7 +3,7 @@ title: "All four agents tied at F1 ~0.95. The number was a mirage."
 subtitle: "Three harnesses, two driver models, four runs. The traces show why an outcome metric on this dataset doesn't mean what the agents reported it means — and a 22-point F1 gap when you actually test for generalisation."
 date: "2026-05-06"
 author: "Daniel van Strien"
-categories: [coding-agents, huggingface, agent-traces, glam, datasets]
+categories: [agents, glam, datasets, huggingface]
 description: "Same one-line prompt, three harnesses, two driver models. The headline F1 tied within 1.5pp. A source-stratified eval the agents didn't run shows the headline number was hiding a 22 F1-point generalisation gap."
 image: judgment-matrix.png
 execute:

--- a/posts/2026/agent-race/index.qmd
+++ b/posts/2026/agent-race/index.qmd
@@ -3,7 +3,7 @@ title: "Two agents, one prompt"
 subtitle: "Pi + Kimi K2.6 and Claude Code both fine-tuned a Jim Crow law classifier from a single sentence. The interesting gap wasn't F1."
 date: "2026-05-01"
 author: "Daniel van Strien"
-categories: [coding-agents, hugging-face, glam, datasets]
+categories: [agents, glam, datasets, huggingface]
 description: "I gave two coding agents the same one-line prompt and watched what each decided to do. Both shipped working classifiers via hf jobs. The headline metrics were within 1.5pp — the interesting differences were everywhere else."
 image: thumbnail.png
 format:

--- a/posts/2026/agent-sentiment/index.qmd
+++ b/posts/2026/agent-sentiment/index.qmd
@@ -9,7 +9,7 @@ author:
   - name: "Claude Opus 4.7"
     url: https://www.anthropic.com/claude
     affiliation: "Anthropic"
-categories: [ai, coding-agents, agent-traces, open-data, huggingface]
+categories: [agents, datasets, huggingface]
 description: "Anthropic, OpenAI, Cursor, and Windsurf sit on millions of private agent traces. The first public corpus has 33 datasets, 1,589 sessions, 8,949 labelled messages. Here's what we found in it — and why the interesting data isn't in the words."
 execute:
   freeze: true

--- a/posts/2026/agent-trained-classifier/index.qmd
+++ b/posts/2026/agent-trained-classifier/index.qmd
@@ -3,7 +3,7 @@ title: "A model release became a training recipe the same day. I mostly watched.
 subtitle: "LiquidAI shipped new encoder models this morning. By the evening there was a fine-tuning recipe, a tutorial dataset, and a working classifier — built by an agent on HF Jobs for under $5 in GPU time."
 date: "2026-07-28"
 author: "Daniel van Strien"
-categories: [huggingface, jobs, agents, fine-tuning, classification]
+categories: [agents, fine-tuning, hf-jobs, huggingface]
 description: "I pasted two links into Claude Code and asked for a training recipe with early smoke tests on HF Jobs. What came back — and why agent-legible infrastructure is what made it work."
 image: confidence-bands.png
 draft: false

--- a/posts/2026/agents-data-curation/index.qmd
+++ b/posts/2026/agents-data-curation/index.qmd
@@ -3,7 +3,7 @@ title: "Using agents to build efficient classifiers for data curation"
 description: "Building a small document classifier with an agent, then using Hugging Face Jobs to label 1% of the English FinePDFs-Edu dataset."
 author: "Daniel van Strien"
 date: "2026-09-10"
-categories: [agents, datasets, classification, hf-jobs]
+categories: [agents, datasets, hf-jobs, huggingface]
 image: card-index.jpg
 image-alt: "A hand selecting a card from an index with labelled drawers."
 open-graph: true

--- a/posts/2026/buckets-data-backend/index.qmd
+++ b/posts/2026/buckets-data-backend/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Filtering 1 TB of FineWeb-Edu for $2.40 using Buckets and Jobs"
 date: "2026-06-02"
-categories: [huggingface, data-engineering, polars, duckdb, jobs]
+categories: [data-engineering, polars, hf-jobs, huggingface]
 description: "A quick look at using Hugging Face Jobs + Storage Buckets to filter a big dataset — DuckDB does the heavy scan, Polars picks up the result, a bucket is the handoff. ~1 TB filtered for about $2.40."
 image: "pipeline.png"
 draft: false

--- a/posts/2026/distilling-qwen38-datatrove-jobs/index.qmd
+++ b/posts/2026/distilling-qwen38-datatrove-jobs/index.qmd
@@ -3,7 +3,7 @@ title: "Distilling Qwen3.8 with datatrove on Hugging Face Jobs"
 subtitle: "35,000 card summaries for $16, no local GPU. Part 1: the data."
 date: "2026-08-17"
 author: "Daniel van Strien"
-categories: [synthetic-data, hf-jobs, datatrove, datasets]
+categories: [synthetic-data, hf-jobs, datasets, huggingface]
 description: "datatrove's new Jobs backend plus a days-old 27B teacher: regenerating a 35,837-summary training dataset in one afternoon for $15.58, with a calibration-first workflow and length-controllable outputs."
 format:
   html:

--- a/posts/2026/hf-streaming-unsloth/train-massive-datasets-without-downloading.ipynb
+++ b/posts/2026/hf-streaming-unsloth/train-massive-datasets-without-downloading.ipynb
@@ -10,7 +10,7 @@
     "title: \"Train on Massive Datasets Without Downloading with Hugging Face Streaming and Unsloth\"\n",
     "description: \"Stream datasets directly from Hugging Face Hub without downloading. Combine streaming with Unsloth for disk-free LLM training on Colab, Kaggle, or HF Jobs.\"\n",
     "author: \"Daniel van Strien\"\n",
-    "categories: [\"huggingface\", \"unsloth\", \"streaming-datasets\", \"fineweb\"]\n",
+    "categories: [huggingface, datasets, fineweb, fine-tuning]\n",
     "date: 2026-01-07\n",
     "image: https://raw.githubusercontent.com/huggingface/blog/refs/heads/main/assets/hf_unsloth/thumbnail.png\n",
     "---"

--- a/posts/2026/nuextract-index-cards/index.md
+++ b/posts/2026/nuextract-index-cards/index.md
@@ -4,18 +4,7 @@ subtitle: "Fine-tuning one open 4B model to read several archival card collectio
 description: "Can a small, open model, fine-tuned cheaply, match a bigger one on a real extraction task and stay general? A test on archival index cards across several collections, for about $45."
 date: "2026-06-24"
 author: "Daniel van Strien"
-categories:
-  [
-    ocr,
-    glam,
-    structured-extraction,
-    vlm,
-    nuextract,
-    index-cards,
-    fine-tuning,
-    huggingface,
-    jobs,
-  ]
+categories: [ocr, glam, structured-extraction, computer-vision, fine-tuning, hf-jobs]
 image: card-to-json.png
 draft: false
 execute:

--- a/posts/2026/ocr-old-scans/index.qmd
+++ b/posts/2026/ocr-old-scans/index.qmd
@@ -3,7 +3,7 @@ title: "Benchmarking OCR fairly is harder than it looks"
 subtitle: "Ten OCR models on olmOCR-bench's hardest scans — and why a model that reads the page more faithfully can score lower."
 date: "2026-07-07"
 author: "Daniel van Strien"
-categories: [ocr, glam, huggingface, jobs, evaluation]
+categories: [ocr, glam, evaluation, hf-jobs]
 description: "I ran ten current OCR models on olmOCR-bench's 'old scans' subset. The ranking flips depending on one thing: whether you want a model that keeps what's on the page, or one that cleans it up. A note on what the headline score actually rewards — and how agents + Jobs made it cheap to run."
 image: cjk-hallucination.png
 draft: false

--- a/posts/2026/re-ocr-collections/index.qmd
+++ b/posts/2026/re-ocr-collections/index.qmd
@@ -2,7 +2,7 @@
 title: "Re-OCR Your Digitised Collections for ~$0.002/Page"
 date: "2026-02-19"
 author: "Daniel van Strien"
-categories: [ocr, glam, huggingface, uv-scripts]
+categories: [ocr, glam, huggingface]
 description: "A guide to re-processing digitised collections with open-source VLM-based OCR models."
 draft: false
 ---

--- a/posts/2026/structured-records-from-cards/index.qmd
+++ b/posts/2026/structured-records-from-cards/index.qmd
@@ -3,7 +3,7 @@ title: "How to turn catalogue card images into structured JSON with a 4B open mo
 subtitle: "A 4B open model turns catalogue-card images into schema-shaped JSON — the kind of structured data that can be ingested back into a library system."
 date: "2026-05-21"
 author: "Daniel van Strien"
-categories: [ocr, glam, huggingface, structured-extraction, datasets]
+categories: [ocr, glam, structured-extraction, datasets, huggingface]
 description: "Re-OCR made digitised catalogue cards searchable as text. But libraries need structured records they can ingest into their catalogues. NuExtract3 (4B, Apache-2.0) extracts schema-shaped JSON from card images in one command — here's how it does, honestly."
 image: nls-card-to-json.png
 format:

--- a/posts/plain-text/2024-05-15-self-instruct.md
+++ b/posts/plain-text/2024-05-15-self-instruct.md
@@ -1,6 +1,6 @@
 ---
 description: _This post is part of a series on synthetic data generation techniques. You may also want to check out [Awesome Synthetic (text) datasets](https://github.com/davanstrien/awesome-synthetic-datasets), where I will be collecting these posts._
-categories: [data, synthetic-data]
+categories: [datasets, synthetic-data]
 title: "Synthetic dataset generation techniques: Self-Instruct"
 date: "2024-05-15"
 ---

--- a/posts/plain-text/autotrain/2023-02-22-autotrain.md
+++ b/posts/plain-text/autotrain/2023-02-22-autotrain.md
@@ -1,6 +1,6 @@
 ---
 description: "How can we train useful machine learning models without writing code?"
-categories: [autotrain]
+categories: [huggingface, fine-tuning]
 title: "Using Hugging Face AutoTrain to train an image classifier without writing any code."
 date: "2023-02-22"
 image: autotrain-image.webp

--- a/posts/plain-text/flyswot/2021-12-22-flyswot.md
+++ b/posts/plain-text/flyswot/2021-12-22-flyswot.md
@@ -1,6 +1,6 @@
 ---
 description: Attempting to deploy machine learning in an existing workflow
-categories: [glam, flyswot]
+categories: [glam, computer-vision, fine-tuning]
 title: "flyswot"
 date: "2021-12-22"
 ---

--- a/posts/plain-text/synthetic-data-generation/2024-05-03-synethic-data-1.md
+++ b/posts/plain-text/synthetic-data-generation/2024-05-03-synethic-data-1.md
@@ -1,6 +1,6 @@
 ---
 description: _This post is part of a series on synthetic data generation techniques. You may also want to check out [Awesome Synthetic (text) datasets](https://github.com/davanstrien/awesome-synthetic-datasets), where I will be collecting these posts._
-categories: [data, synthetic-data]
+categories: [datasets, synthetic-data]
 title: "Synthetic dataset generation techniques\\: generating custom sentence similarity data"
 date: "2024-05-23"
 ---

--- a/posts/post-with-code/2020-05-03-multi-model.ipynb
+++ b/posts/post-with-code/2020-05-03-multi-model.ipynb
@@ -9,6 +9,7 @@
     "description: \"Experiment in combining text and tabular models to generate web archive metadata\"\n",
     "author: \"Daniel van Strien\"\n",
     "date: \"2020-05-03\"\n",
+    "categories: [datasets, computer-vision]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/2020-10-12-labelling_vs_classification_models.ipynb
+++ b/posts/post-with-code/2020-10-12-labelling_vs_classification_models.ipynb
@@ -9,6 +9,7 @@
     "description: \"Comparing the loss functions of label and classification models\"\n",
     "author: \"Daniel van Strien\"\n",
     "date: \"2020-10-12\"\n",
+    "categories: [computer-vision, datasets]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/2021-12-30-hf-hub-model-storage.ipynb
+++ b/posts/post-with-code/2021-12-30-hf-hub-model-storage.ipynb
@@ -9,6 +9,7 @@
     "description: \"How I'm planning to use the huggingface hub for storing flyswot models\" \n",
     "author: \"Daniel van Strien\"\n",
     "date: \"2021-12-30\"\n",
+    "categories: [huggingface]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/2022-01-13-image_search.ipynb
+++ b/posts/post-with-code/2022-01-13-image_search.ipynb
@@ -13,6 +13,7 @@
     "date: \"2022-01-13\"\n",
     "aliases:\n",
     "    - metadata/deployment/huggingface/ethics/huggingface-datasets/faiss/2022/01/13/image_search.html\n",
+    "categories: [computer-vision, datasets, huggingface]\n",
     "---\n"
    ]
   },

--- a/posts/post-with-code/2023-06-07-hub-dataset-danguage_detection.ipynb
+++ b/posts/post-with-code/2023-06-07-hub-dataset-danguage_detection.ipynb
@@ -10,6 +10,7 @@
     "description: Using the huggingface_hub library to asses metadata on the hub\n",
     "author: \"Daniel van Strien\"\n",
     "date: \"2023-06-07\"\n",
+    "categories: [datasets, huggingface]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/colpali-qdrant/2024-10-02_using_colpali_with_qdrant.ipynb
+++ b/posts/post-with-code/colpali-qdrant/2024-10-02_using_colpali_with_qdrant.ipynb
@@ -11,6 +11,7 @@
     "date: \"2024-10-02\"\n",
     "image: truth.png \n",
     "toc-depth: 3\n",
+    "categories: [computer-vision, huggingface]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/colpali/2024-09-23-generate_colpali_dataset.ipynb
+++ b/posts/post-with-code/colpali/2024-09-23-generate_colpali_dataset.ipynb
@@ -12,6 +12,7 @@
     "image: cJkPlaOVIju5yR7TaO0fD.png\n",
     "toc: true\n",
     "toc-depth: 3\n",
+    "categories: [computer-vision, datasets, synthetic-data]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/dask/2022-06-20-dask-and-datasets.ipynb
+++ b/posts/post-with-code/dask/2022-06-20-dask-and-datasets.ipynb
@@ -10,6 +10,7 @@
     "author: \"Daniel van Strien\"\n",
     "date: \"2022-06-20\"\n",
     "image: dask_plot_example.png\n",
+    "categories: [datasets, huggingface, data-engineering]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/datasets-groupby/2023-09-18-datasets-groupby.ipynb
+++ b/posts/post-with-code/datasets-groupby/2023-09-18-datasets-groupby.ipynb
@@ -11,6 +11,7 @@
         "date: \"2023-09-18\" \n",
         "frozen: true\n",
         "image: groupby-fig.png\n",
+        "categories: [datasets, huggingface]\n",
         "---"
       ]
     },

--- a/posts/post-with-code/datasets-with-qdrant/2023-11-08-datasets_to_qdrant.ipynb
+++ b/posts/post-with-code/datasets-with-qdrant/2023-11-08-datasets_to_qdrant.ipynb
@@ -11,6 +11,7 @@
         "date: \"2023/11/08\"\n",
         "draft: false\n",
         "frozen: true\n",
+        "categories: [datasets, huggingface, data-engineering]\n",
         "---"
       ]
     },

--- a/posts/post-with-code/detr/2022-08-16-detr-object-detection.ipynb
+++ b/posts/post-with-code/detr/2022-08-16-detr-object-detection.ipynb
@@ -10,6 +10,7 @@
     "author: \"Daniel van Strien\"\n",
     "date: \"2022-08-16\"\n",
     "image: https://raw.githubusercontent.com/davanstrien/blog/4100b7d4db7def820bde7930934f1094af87accf/images/detr_model_output.webp \n",
+    "categories: [computer-vision, fine-tuning, huggingface]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/label-studio-hub/2022-09-07-label-studio-annotations-hub.ipynb
+++ b/posts/post-with-code/label-studio-hub/2022-09-07-label-studio-annotations-hub.ipynb
@@ -10,6 +10,7 @@
     "author: \"Daniel van Strien\"\n",
     "date: \"2022-09-07\"\n",
     "image: huggingface_hub_label_possum.webp\n",
+    "categories: [huggingface, datasets]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/langfuse-tracing/Langfuse_+_HF_inference_endpoints.ipynb
+++ b/posts/post-with-code/langfuse-tracing/Langfuse_+_HF_inference_endpoints.ipynb
@@ -11,6 +11,7 @@
         "date: \"4/05/2024\"\n",
         "draft: false\n",
         "frozen: true\n",
+        "categories: [huggingface, evaluation]\n",
         "---"
       ]
     },

--- a/posts/post-with-code/metadata-explore/2023_01_16_hub_api_explore copy.ipynb
+++ b/posts/post-with-code/metadata-explore/2023_01_16_hub_api_explore copy.ipynb
@@ -12,6 +12,7 @@
     "author: \"Daniel van Strien\"\n",
     "date: \"2023-01-16\"\n",
     "image: hub.png\n",
+    "categories: [huggingface, datasets]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/optuna/2020-07-01-optuna.ipynb
+++ b/posts/post-with-code/optuna/2020-07-01-optuna.ipynb
@@ -13,6 +13,7 @@
     "author: \"Daniel van Strien\"\n",
     "image: \"optuna.png\"\n",
     "date: \"2020-07-01\"\n",
+    "categories: [fine-tuning, computer-vision]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/readme_auto_generate/2023-03-07-readme-template.ipynb
+++ b/posts/post-with-code/readme_auto_generate/2023-03-07-readme-template.ipynb
@@ -13,6 +13,7 @@
     "author: \"Daniel van Strien\"\n",
     "date: 2023-03-07\"\n",
     "image: preview.png\n",
+    "categories: [huggingface]\n",
     "---"
    ]
   },

--- a/posts/post-with-code/semantic-model-search/2022-07-26-semantic-search-ml-models.ipynb
+++ b/posts/post-with-code/semantic-model-search/2022-07-26-semantic-search-ml-models.ipynb
@@ -13,6 +13,7 @@
     "date: 2022-07-26\n",
     "author: \"Daniel van Strien\"\n",
     "image: https://github.com/davanstrien/blog/blob/master/images/hub_model_search.webp?raw=true\n",
+    "categories: [huggingface]\n",
     "---"
    ]
   },


### PR DESCRIPTION
## What

Normalises the `categories` frontmatter of all **45 published posts** to a controlled 17-tag vocabulary. YAML-only diff — no URLs, titles, dates, or content change.

Follows up on #98 (`huggingface` spelling) with the full scheme.

## Why

Categories currently exist in 48 distinct spellings across the archive, including three spellings of the same concept (`jobs` / `hf-jobs` / `hf Jobs`), case variants (`glam`/`GLAM`, `ai`/`AI`), and 23 one-off tags (mostly model names already in post titles). 18 older posts have no categories at all. Result: the listing's category filter is noise. After this PR: **17 tags, zero variants, every post tagged (2–4 tags, avg ~3).**

## Vocabulary

| Tier | Tags |
|---|---|
| Topics | `huggingface` (36) `datasets` (25) `computer-vision` (11) `fine-tuning` (10) `glam` (8) `synthetic-data` (6) `agents` (5) `ocr` (4) `structured-extraction` (3) `data-engineering` (3) `evaluation` (2) |
| Tools | `hf-jobs` (8) `polars` (4) `vllm` (2) `fineweb` (3) |
| Kept singletons | `libraries` (1) `art-history` (1) `local-ai` (1, deliberate seed for upcoming local/on-device posts) |

`computer-vision` is the only new tag applied broadly (absorbs `vlm`, plus 8 untagged image posts → instant 11-post cluster).

## Merges / drops

- `jobs` + `hf Jobs` → `hf-jobs`; `uv-scripts` dropped (Jobs posts get `hf-jobs`)
- `coding-agents` + `agent-traces` → `agents`; `ai`/`AI` dropped (too vague)
- `data` + `open-data` → `datasets`; `GLAM` → `glam`
- `classification` → `fine-tuning`; `community` → `libraries`
- Dropped model/tool one-offs: `qwq` `deepseek` `modernbert` `nuextract` `unsloth` `flyswot` `autotrain` `iconclass` `index-cards` `duckdb` `datatrove` `streaming-datasets` `trl` `arxiv` `reasoning` `github` `claude` `data-analysis`

## Scope

- **41 files edited**; 4 posts already compliant and untouched (`fineweb-filter-polars`, `how-fine-is-fineweb2`, `scandinavian-content-filtering-fineweb`, `model-card`)
- Drafts and unpublished posts excluded
- `hf-jobs` implies `huggingface`, so Jobs-centric posts sometimes drop the latter

## Validation

- Automated audit: for all 41 files, parsed frontmatter is identical before/after except `categories`; notebook cells/metadata byte-identical except the frontmatter cell
- Spot renders (`flyswot`, `nuextract`, `grpo`) produce the expected category badges; notebook JSON round-trips byte-identical
